### PR TITLE
Declare support for Heroku-20

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -9,4 +9,7 @@ name = "Procfile"
 id = "heroku-18"
 
 [[stacks]]
+id = "heroku-20"
+
+[[stacks]]
 id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
In the future we'll presumably want to declare this buildpack as an any-stack buildpack using the new `"*"` syntax:
https://github.com/buildpacks/spec/pull/155

However until `pack` uses a lifecycle release that includes buildpack API 0.5 or higher, we must continue to explicitly list the stacks.

For more on the remaining Heroku-20 tasks, see:
https://salesforce.quip.com/LbhlAFPd1rvR#fCAACA6FA2X

Closes [W-8270771](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008hLznIAE/view).