### PR TITLE
Update to support any stack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
                 go-version: '^1.12.1'
             - id: setup-pack
               name: Install Pack
-              uses: buildpacks/github-actions/setup-pack@v4.0.0
+              uses: buildpacks/github-actions/setup-pack@v4.2.0
             - id: compile
               name: Compile Buildpack
               run: |
@@ -47,7 +47,7 @@ jobs:
                 PACKAGE: docker.io/heroku/procfile-cnb
             - id: register
               name: Register Buildpack
-              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.0
+              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.2.0
               with:
                 token:   ${{ secrets.PUBLIC_REPO_TOKEN }}
                 id:      heroku/procfile

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
 id = "heroku/procfile"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,15 +1,9 @@
-api = "0.2"
+api = "0.5"
 
 [buildpack]
 id = "heroku/procfile"
-version = "0.6.2"
+version = "0.7.0"
 name = "Procfile"
 
 [[stacks]]
-id = "heroku-18"
-
-[[stacks]]
-id = "heroku-20"
-
-[[stacks]]
-id = "io.buildpacks.stacks.bionic"
+id = "*"


### PR DESCRIPTION
Also updates:
* Buildpack API version to 0.6 (0.5 is required for `*` stack)
* CNB github-actions to 4.2.0