### PR TITLE
Add missing metadata to buildpack.toml

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -4,6 +4,9 @@ api = "0.6"
 id = "heroku/procfile"
 version = "0.7.1"
 name = "Procfile"
+homepage = "https://github.com/heroku/procfile-cnb"
+description = "Official Heroku buildpack for using Procfile."
+keywords = ["procfile", "processes"]
 
 [[stacks]]
 id = "*"


### PR DESCRIPTION
Add metadata for registry page https://registry.buildpacks.io/buildpacks/heroku/procfile