### PR TITLE
Skip integration tests when using `cargo test`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           command: rustup target add x86_64-unknown-linux-musl
       - run:
           name: Run tests
-          command: RUST_BACKTRACE=1 cargo test --all-features --locked
+          command: RUST_BACKTRACE=1 cargo test --all-features --locked -- --include-ignored
       - save-cargo-cache
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Run unit tests:
 $ cargo test
 ```
 
+Run integration tests:
+
+```
+$ cargo test -- --ignored
+```
+
+Or to run all of the tests at the same time:
+
+```
+$ cargo test -- --include-ignored
+```
+
 ### Pack build example
 
 ```

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,12 @@
+//! Integration tests using libcnb-test.
+//!
+//! All integration tests are skipped by default (using the `ignore` attribute),
+//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+
 use libcnb_test::{BuildpackReference, IntegrationTest};
 
 #[test]
+#[ignore]
 fn test() {
     IntegrationTest::new("heroku/buildpacks:20", "tests/fixtures/app_with_procfile")
         .buildpacks(vec![BuildpackReference::Crate])


### PR DESCRIPTION
The integration test is now annotated with the `#[ignore]` attribute, which causes it to be skipped by default when using `cargo test`.

This allows for more easily running just the unit tests, which are faster and don't require Docker to be running.

For more details, see:
https://github.com/Malax/libcnb.rs/pull/316

GUS-W-10736354.