### PR TITLE
Make crate as `publish = false`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "procfile-buildpack"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "indoc",
  "libcnb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "procfile-buildpack"
-version = "0.1.0"
+# The crate is not published, so the only version that is used is the one in buildpack.toml.
+version = "0.0.0"
+publish = false
 edition = "2021"
 rust-version = "1.57"
 


### PR DESCRIPTION
Since the buildpack doesn't need to be published to crates.io.

The version in `Cargo.toml` has also been zeroed out, to reduce the chance of confusion between it and the version in `buildpack.toml`.

(I plan to backport this to the `libcnb.rs` examples - didn't realise it was missing from them).

GUS-W-10736354.