### PR TITLE
Remove structure section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,38 +34,3 @@ Processes:
   web (default)        bash         node index.js
   worker               bash         while true; do echo 'lol'; sleep 2; done
 ```
-
-### Structure
-
-The code produces a single binary that contain both the "detect" and "build" interfaces:
-
-```rs
-fn main() {
-    cnb_runtime(detect, build, GenericErrorHandler);
-}
-```
-
-The function `cnb_runtime` changes behavior based on the name of the calling file. In the `Makefile.toml` the binary is symlinked with different names (`detect` versus `build`):
-
-```rs
-fs::hard_link(destination.join("bin/build"), destination.join("bin/detect")).unwrap();
-```
-
-The package can be complied for linux (musl) by running:
-
-```
-cargo make pack --profile "production"
-```
-
-This produces a `target/bin/detect` and `target/bin/build` that can be used for pack.
-
-The functionality of those two binaries are come from the functions with the same name:
-
-```rs
-fn detect(context: GenericDetectContext) -> Result<DetectOutcome, E> {
-  //...
-}
-fn build(context: GenericDetectContext) -> Result<(), E> {
-  // ...
-}
-```


### PR DESCRIPTION
Since:
- it's out of date (that's not the way `libcnb.rs` works any more)
- we shouldn't be trying to duplicate `libcnb.rs` docs here
- understanding the inner mechanics of how the buildpack is packaged by `cargo libcnb package` is both not necessary to work on this buildpack, but also part of the design principal behind `libcnb.rs` (ie: it takes care of it, so you don't have to).

If further documentation is desired, it should be added to `libcnb.rs`'s docs and linked to from here, rather than duplicated.

GUS-W-10736354.