### PR TITLE
Add a `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @heroku/languages


### PR DESCRIPTION
Based on that used in our other repos, eg:
https://github.com/heroku/heroku-buildpack-python/blob/main/.github/CODEOWNERS

GUS-W-10736354.