### PR TITLE
Bump buildpack version to 1.0.0

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.6"
 
 [buildpack]
 id = "heroku/procfile"
-version = "0.8.0"
+version = "1.0.0"
 name = "Procfile"
 homepage = "https://github.com/heroku/procfile-cnb"
 description = "Official Heroku buildpack for using Procfile."


### PR DESCRIPTION
Now seems like as good a time as any to bump the version to v1, now that the buildpack has been rewritten using `libcnb.rs` and has much better test coverage.

This will also make it easier to tell pre and post rewrite versions apart (`v0.x` vs. `v1.x`).

GUS-W-10736354.