### PR TITLE
Remove unnecessary install of `libcnb-cargo` in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: cargo fmt -- --check --verbose
       - save-cargo-cache
 
-  build-and-test:
+  test:
     executor: rust
     steps:
       - checkout
@@ -56,9 +56,6 @@ jobs:
       - run:
           name: Install musl
           command: sudo apt-get update && sudo apt-get install musl-tools --no-install-recommends
-      - run:
-          name: Install libcnb build tool
-          command: cargo install libcnb-cargo
       - run:
           name: Add musl target
           command: rustup target add x86_64-unknown-linux-musl
@@ -71,4 +68,4 @@ workflows:
   ci:
     jobs:
       - lint
-      - build-and-test
+      - test


### PR DESCRIPTION
Since it's not required to run the integration tests, and will only used by the release process, which will happen separately in a GitHub Action as part of #41. 

This saves ~4 minutes of CI time when the cache is cold (which is any time `Cargo.lock` or the Circle CI config changes), or when a new version of `libcnb-cargo` has been released.

GUS-W-10736354.