### PR TITLE
Add explicit support for heroku-* stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 1.0.1
+- Added explicit support for heroku-* stacks.
+
 ## 1.0.0
 
 - Initial release of Rust procfile buildpack, the old Go buildpack is now archived.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.6"
 
 [buildpack]
 id = "heroku/procfile"
-version = "1.0.0"
+version = "1.0.1"
 name = "Procfile"
 homepage = "https://github.com/heroku/procfile-cnb"
 description = "Official Heroku buildpack for using Procfile."

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,5 +11,14 @@ keywords = ["procfile", "processes"]
 [[stacks]]
 id = "*"
 
+[[stacks]]
+id = "heroku-18"
+
+[[stacks]]
+id = "heroku-20"
+
+[[stacks]]
+id = "heroku-20"
+
 [[buildpack.licenses]]
 type = "BSD-3-Clause"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,6 +11,9 @@ keywords = ["procfile", "processes"]
 [[stacks]]
 id = "*"
 
+# Explicit stack identifiers are required for `pack` versions `0.24.0`
+# and older. `heroku-*` stack identifiers may be removed once the buildpack 
+# api is upgraded to something greater than "0.6".
 [[stacks]]
 id = "heroku-18"
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -18,7 +18,7 @@ id = "heroku-18"
 id = "heroku-20"
 
 [[stacks]]
-id = "heroku-20"
+id = "heroku-22"
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"


### PR DESCRIPTION
Some older versions of `pack` (prior to `0.24.1`) fail to recognize this buildpack's `*` stack support. By adding the `heroku-*` stacks explicitly, we ensure this buildpack works on older `pack` versions (at least on `heroku-*` stacks).

This issue bit a user here: https://cloud-native.slack.com/archives/C033DV8D9FB/p1649105014643919
And caused another buildpack a bit of trouble here: https://github.com/heroku/buildpacks-nodejs/pull/231#pullrequestreview-930764164