### PR TITLE
Adjust tag name when creating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,5 @@ jobs:
               with:
                 repo_token: ${{ secrets.GITHUB_TOKEN }}
                 file: ${{ steps.package.outputs.package }}
-                tag: ${{ github.ref }}
-                tag_name: ${{ steps.package.outputs.version }}
+                tag: ${{ steps.package.outputs.version }}
                 overwrite: true


### PR DESCRIPTION
The latest `release` action made a slightly weird release: https://github.com/heroku/procfile-cnb/releases/tag/main. It used `main` as a tag, which doesn't look right. This PR changes the publish action release to use the version number as the tag/release title.