### PR TITLE
Update pack to 0.24.1 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - restore-cargo-cache
       - install-rust
       - pack/install-pack:
-          version: 0.23.0
+          version: 0.24.1
       - run:
           name: Install musl
           command: sudo apt-get update && sudo apt-get install musl-tools --no-install-recommends


### PR DESCRIPTION
There have been a few updates we should pick up (https://github.com/buildpacks/pack/releases/tag/v0.24.0, https://github.com/buildpacks/pack/releases/tag/v0.24.1).

[W-10708989](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000ozUkOYAU)