### PR TITLE
Rename `PUBLIC_REPO_TOKEN` to `CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
             - id: register
               uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.2.0
               with:
-                token:   ${{ secrets.PUBLIC_REPO_TOKEN }}
+                token:   ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
                 id:      ${{ steps.package.outputs.bp_id }}
                 version: ${{ steps.package.outputs.version }}
                 address: ${{ steps.package.outputs.address }}


### PR DESCRIPTION
Since `PUBLIC_REPO_TOKEN` doesn't mention GitHub, and the "repo" part of the name could also be relating to Docker Hub or ECR repositories.

I've not used the name `GITHUB_TOKEN`, since for GitHub Actions there is already an env var of that name provided automatically. That env var isn't suitable for publishing CNB releases, since we need to open an issue against the upstream CNB registry's index repo to trigger a release, whereas the GH Actions provided token only gives access to the repository where the action ran.