### PR TITLE
Switch to `heroku/builder:22` for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ cargo test -- --include-ignored
 
 ```
 $ cargo libcnb package \
-&& pack build procfile_example_app --builder heroku/buildpacks:20 --buildpack target/buildpack/debug/heroku_procfile --path tests/fixtures/app_with_procfile --verbose \
+&& pack build procfile_example_app --builder heroku/builder:22 --buildpack target/buildpack/debug/heroku_procfile --path tests/fixtures/app_with_procfile --verbose \
 && docker run -it --rm --entrypoint worker procfile_example_app
 ```
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 #[test]
 #[ignore]
 fn test() {
-    IntegrationTest::new("heroku/buildpacks:20", "tests/fixtures/app_with_procfile")
+    IntegrationTest::new("heroku/builder:22", "tests/fixtures/app_with_procfile")
         .buildpacks(vec![BuildpackReference::Crate])
         .run_test(|context| {
             assert_contains!(context.pack_stdout, "[Discovering process types]");


### PR DESCRIPTION
Since it supersedes `heroku/buildpacks:20`:
https://github.com/heroku/builder#heroku-builder-images