### PR TITLE
Remove `--all-features` usages from Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - run:
           name: Clippy
           # Using --all-targets so tests are checked and --deny to fail on warnings.
-          command: cargo clippy --all-targets --all-features --locked -- --deny warnings
+          command: cargo clippy --all-targets --locked -- --deny warnings
       - run:
           name: rustfmt
           command: cargo fmt -- --check --verbose
@@ -65,7 +65,7 @@ jobs:
           command: pack config trusted-builders add heroku/builder:22
       - run:
           name: Run tests
-          command: cargo test --all-features --locked -- --include-ignored
+          command: cargo test --locked -- --include-ignored
       - save-cargo-cache
 
 workflows:


### PR DESCRIPTION
Since this project doesn't use Cargo features, and whilst having the flag there doesn't cause any issues, the CI config here is being used as a reference by other projects, where the sheer number of flags used has been seen to cause confusion/need people to resort to bash aliases to remember what command to run etc.