### PR TITLE
Update libcnb to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Upgrade `libcnb` and `libherokubuildpack` to `0.10.0`. ([#98](https://github.com/heroku/procfile-cnb/pull/98))
+- Buildpack now implements buildpack API version `0.8` and so requires lifecycle version `0.14.x` or newer. ([#98](https://github.com/heroku/procfile-cnb/pull/98))
+
 ## 1.0.2
 
 - Strip buildpack binary for reduced builder image size (thanks to [`libcnb-cargo` v0.5.0](https://github.com/heroku/libcnb.rs/releases/tag/libcnb-cargo%2Fv0.5.0)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,22 +544,23 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libcnb"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a8206c9c5004aa37c8369e27494cdda7744611f4b39f95b5bbbbd5a9365c20"
+checksum = "4d67f6f6f7dd0a13fce25a9247fd9a0e5cbe97c8431fee0008c674602e36c9e4"
 dependencies = [
  "libcnb-data",
  "libcnb-proc-macros",
  "serde",
+ "stacker",
  "thiserror",
  "toml",
 ]
 
 [[package]]
 name = "libcnb-data"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498e6ba7cfd2520053c75d1a3f4f98f09d0e45103f043f7f8cfe422b236b8e4b"
+checksum = "52cd3749d2c63a77a4d2b069904ecb526977692352186ec3094b15df50c71ee3"
 dependencies = [
  "fancy-regex",
  "libcnb-proc-macros",
@@ -570,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-package"
-version = "0.2.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac843541f7874babc40106a52e35972931f66ca95e5adabbc8b20ca36063e5ea"
+checksum = "3e245f2e25a5fc10593db933f25e739f9c5a6d0f944c3bebac6b282e0a9888a1"
 dependencies = [
  "cargo_metadata",
  "libcnb-data",
@@ -582,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "libcnb-proc-macros"
-version = "0.3.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21023e1598df3f6fea1b188a34ce06ca41181f03ed3d71169ebaa58c8cfd278b"
+checksum = "f298d2d11525f72ea88e0f529372d11e62b1410c2f11a65c8eb061581597710f"
 dependencies = [
  "cargo_metadata",
  "fancy-regex",
@@ -594,14 +595,15 @@ dependencies = [
 
 [[package]]
 name = "libcnb-test"
-version = "0.6.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8111541bbccb29e423bc8904f0d750793a484601fd52b177bd478af544c6f2"
+checksum = "a8987577ad4be4171cbb730e7a23be913a5a83da624a6ea9eb5457ab9a55c405"
 dependencies = [
  "bollard",
  "cargo_metadata",
  "fastrand",
  "fs_extra",
+ "libcnb-data",
  "libcnb-package",
  "serde",
  "tempfile",
@@ -611,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "libherokubuildpack"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896572dbc018df95e8539bfdadd8da6fc5646d41c2f8cadfe31075b0ef7bc57c"
+checksum = "ea1621294a166cafb93e9df130da45d951ed26910b209d4c356684028e53b4f4"
 dependencies = [
  "flate2",
  "libcnb",
@@ -752,6 +754,15 @@ dependencies = [
  "libherokubuildpack",
  "linked-hash-map",
  "regex",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f446d0a6efba22928558c4fb4ce0b3fd6c89b0061343e390bf01a703742b8125"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -950,6 +961,19 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ rust-version = "1.61"
 
 [dependencies]
 indoc = "1.0.7"
-libcnb = "0.9.0"
-libherokubuildpack = "0.9.0"
+libcnb = "0.10.0"
+libherokubuildpack = "0.10.0"
 linked-hash-map = "0.5.6"
 regex = "1.6.0"
 
 [dev-dependencies]
-libcnb-test = "0.6.0"
+libcnb-test = "0.10.0"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.6"
+api = "0.8"
 
 [buildpack]
 id = "heroku/procfile"
@@ -12,7 +12,7 @@ keywords = ["procfile", "processes"]
 id = "*"
 
 # Explicit stack identifiers are required for `pack` versions `0.24.0`
-# and older. `heroku-*` stack identifiers may be removed once the buildpack 
+# and older. `heroku-*` stack identifiers may be removed once the buildpack
 # api is upgraded to something greater than "0.6".
 [[stacks]]
 id = "heroku-18"

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,12 +1,16 @@
 use crate::Procfile;
-use libcnb::data::launch::{Launch, Process, ProcessType};
+use libcnb::data::launch::{Launch, Process, ProcessType, WorkingDirectory};
 use std::str::FromStr;
 
 impl TryFrom<Procfile> for Launch {
     type Error = ProcfileConversionError;
 
     fn try_from(value: Procfile) -> Result<Self, Self::Error> {
-        let mut launch = Launch::new();
+        let mut launch = Launch {
+            labels: vec![],
+            processes: vec![],
+            slices: vec![],
+        };
 
         for (key, value) in value.processes {
             launch.processes.push(Process {
@@ -16,6 +20,7 @@ impl TryFrom<Procfile> for Launch {
                 args: Vec::<String>::new(),
                 direct: false,
                 default: key == "web",
+                working_directory: WorkingDirectory::App,
             });
         }
 
@@ -37,7 +42,7 @@ pub enum ProcfileConversionError {
 #[cfg(test)]
 mod test {
     use crate::Procfile;
-    use libcnb::data::launch::{Launch, Process};
+    use libcnb::data::launch::{Launch, Process, WorkingDirectory};
     use libcnb::data::process_type;
 
     #[test]
@@ -54,7 +59,8 @@ mod test {
                 command: String::from("web_command"),
                 args: vec![],
                 direct: false,
-                default: true
+                default: true,
+                working_directory: WorkingDirectory::App,
             }]
         );
     }
@@ -73,7 +79,8 @@ mod test {
                 command: String::from("xxx_command"),
                 args: vec![],
                 direct: false,
-                default: true
+                default: true,
+                working_directory: WorkingDirectory::App,
             }]
         );
     }
@@ -94,14 +101,16 @@ mod test {
                     command: String::from("web_command"),
                     args: vec![],
                     direct: false,
-                    default: true
+                    default: true,
+                    working_directory: WorkingDirectory::App,
                 },
                 Process {
                     r#type: process_type!("foo"),
                     command: String::from("foo_command"),
                     args: vec![],
                     direct: false,
-                    default: false
+                    default: false,
+                    working_directory: WorkingDirectory::App,
                 }
             ]
         );
@@ -123,14 +132,16 @@ mod test {
                     command: String::from("foo_command"),
                     args: vec![],
                     direct: false,
-                    default: false
+                    default: false,
+                    working_directory: WorkingDirectory::App,
                 },
                 Process {
                     r#type: process_type!("bar"),
                     command: String::from("bar_command"),
                     args: vec![],
                     direct: false,
-                    default: false
+                    default: false,
+                    working_directory: WorkingDirectory::App,
                 }
             ]
         );
@@ -161,21 +172,24 @@ mod test {
                     command: String::from("aaa_command"),
                     args: vec![],
                     direct: false,
-                    default: false
+                    default: false,
+                    working_directory: WorkingDirectory::App,
                 },
                 Process {
                     r#type: process_type!("ccc"),
                     command: String::from("ccc_command"),
                     args: vec![],
                     direct: false,
-                    default: false
+                    default: false,
+                    working_directory: WorkingDirectory::App,
                 },
                 Process {
                     r#type: process_type!("bbb"),
                     command: String::from("bbb_command"),
                     args: vec![],
                     direct: false,
-                    default: false
+                    default: false,
+                    working_directory: WorkingDirectory::App,
                 },
             ]
         );


### PR DESCRIPTION
Update `libcnb` and `libherokubuildpack` to `0.10.0` and therefore to buildpack API `0.8` as well.

Closes GUS-W-11680349