### PR TITLE
Remove redundant explicitly named stacks from `[[stacks]]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Remove redundant explicitly named stacks from `[[stacks]]`. ([#103](https://github.com/heroku/procfile-cnb/pull/103))
 - Upgrade `libcnb` and `libherokubuildpack` to `0.11.0`. ([#98](https://github.com/heroku/procfile-cnb/pull/98) and [#102](https://github.com/heroku/procfile-cnb/pull/102))
 - Buildpack now implements buildpack API version `0.8` and so requires lifecycle version `0.14.x` or newer. ([#98](https://github.com/heroku/procfile-cnb/pull/98))
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,17 +11,5 @@ keywords = ["procfile", "processes"]
 [[stacks]]
 id = "*"
 
-# Explicit stack identifiers are required for `pack` versions `0.24.0`
-# and older. `heroku-*` stack identifiers may be removed once the buildpack
-# api is upgraded to something greater than "0.6".
-[[stacks]]
-id = "heroku-18"
-
-[[stacks]]
-id = "heroku-20"
-
-[[stacks]]
-id = "heroku-22"
-
 [[buildpack.licenses]]
 type = "BSD-3-Clause"


### PR DESCRIPTION
Since the buildpack already declares compatibility with the wildcard stack, and newer versions of Pack no longer need the explicit stack identifiers as a workaround.

GUS-W-11816021.