### PR TITLE
Fix permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
         name: Package, Publish, and Register
         runs-on:
             - ubuntu-22.04
+        permissions:
+          contents: write
         steps:
             # Needed to get the buildpack code
             - name: Checkout


### PR DESCRIPTION
I noticed this in the https://github.com/heroku/buildpacks-jvm repository. It looks like the default token permissions have been overridden by an org-wide policy. This change restores the required permissions for the release workflow. Since the release workflow in this repository does not open a PR for post-release updates, the `pull-request` permission isn't added (like in the JVM and Node repositories)

Refs: https://github.com/heroku/buildpacks-jvm/pull/389, GUS-W-11937667