### PR TITLE
Use the shared GitHub Actions workflows for buildpack releases

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,10 +13,6 @@ on:
           - minor
           - patch
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   prepare-release:
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-prepare-release.yml@main

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,28 @@
+name: Prepare Buildpack Releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Bump"
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-prepare-release.yml@main
+    with:
+      bump: ${{ inputs.bump }}
+      declarations_starting_version: 1.0.0
+      app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+    secrets:
+      app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,4 +1,4 @@
-name: Prepare Buildpack Releases
+name: Prepare Buildpack Release
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
       bump:
         description: "Bump"
         required: true
-        default: 'patch'
+        default: "patch"
         type: choice
         options:
           - major

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -22,7 +22,6 @@ jobs:
     uses: heroku/languages-github-actions/.github/workflows/_buildpacks-prepare-release.yml@main
     with:
       bump: ${{ inputs.bump }}
-      declarations_starting_version: 1.0.0
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,106 +1,81 @@
-name: release
+name: Release Buildpacks
 
-# Allow the action to be triggered manually in the "actions"
-# tab of GitHub.
 on:
-  workflow_dispatch
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-    release:
-        name: Package, Publish, and Register
-        runs-on:
-            - ubuntu-22.04
-        permissions:
-          contents: write
-        steps:
-            # Needed to get the buildpack code
-            - name: Checkout
-              uses: actions/checkout@v3
+  detect:
+    name: Detecting Buildpacks
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-detect.yml@main
 
-            # Install musl gcc needed to compile rust buildpack
-            # to linux musl target
-            - name: Install musl-tools
-              run: sudo apt-get install musl-tools --no-install-recommends
+  package:
+    name: ${{ matrix.buildpack_id }}
+    needs: [ detect ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-package.yml@main
+    with:
+      buildpack_id: ${{ matrix.buildpack_id }}
+      buildpack_dir: ${{ matrix.buildpack_dir }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
 
-            # Get the `pack` command for packaging the buildpack
-            - id: setup-pack
-              name: Install Pack
-              uses: buildpacks/github-actions/setup-pack@v5.2.0
+  publish-docker:
+    name: ${{ matrix.buildpack_id }}
+    needs: [ detect, package ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-docker.yml@main
+    with:
+      buildpack_id: ${{ matrix.buildpack_id }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
+      docker_repository: ${{ matrix.docker_repository }}
+    secrets:
+      docker_hub_user: ${{ secrets.DOCKER_HUB_USER }}
+      docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-            - name: Install yj
-              uses: buildpacks/github-actions/setup-tools@v5.2.0
+  publish-github:
+    name: ${{ matrix.buildpack_id }}
+    needs: [ detect, package ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-github.yml@main
+    with:
+      buildpack_version: ${{ matrix.buildpack_version }}
+      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
 
-            # Used by `pack buildpack package --publish`. The buildpack
-            # will be published to this user and password
-            - name: Login to Docker Hub
-              uses: docker/login-action@v2
-              with:
-                registry: docker.io
-                username: ${{ secrets.DOCKER_HUB_USER }}
-                password: ${{ secrets.DOCKER_HUB_TOKEN }}
+  publish-cnb:
+    name: ${{ matrix.buildpack_id }}
+    needs: [ detect, publish-docker ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-cnb-registry.yml@main
+    with:
+      buildpack_id: ${{ matrix.buildpack_id }}
+      buildpack_version: ${{ matrix.buildpack_version }}
+      docker_repository: ${{ matrix.docker_repository }}
+    secrets:
+      cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
 
-            # Most of the time this will be a no-op, since GitHub releases new images every week
-            # which include the latest stable release of Rust, Rustup, Clippy and rustfmt.
-            - name: Update Rust toolchain
-              run: rustup update
-            - name: Rust Cache
-              uses: Swatinem/rust-cache@v2.4.0
-
-            # Needed to get `cargo libcnb package` command
-            - name: Install libcnb plugin
-              run: cargo install libcnb-cargo
-            # Configure Rust so it knows how to compile to the linux musl target
-            - name: Install Rust linux-musl target
-              run: rustup target add x86_64-unknown-linux-musl
-            # Compile the rust buildpack
-            - id: package-libcnb-rs
-              run: cargo libcnb package --release
-
-            # Pull out data from the buildpacks `buildpack.toml` to make
-            # it available to other commands. Also package and publish
-            # the buildpack to docker hub as well as generate a local
-            # file containing the buildpack.
-            - id: package
-              run: |
-                #!/usr/bin/env bash
-                set -euo pipefail
-                BP_ID="$(cat buildpack.toml | yj -t | jq -r .buildpack.id)"
-                VERSION="$(cat buildpack.toml | yj -t | jq -r .buildpack.version)"
-                ESCAPED_ID="$(echo "$BP_ID" | sed 's/\//_/g')"
-                PACKAGE="${REPO}"
-
-                # --publish pushes to the registry (logged in)
-                pack buildpack package --publish --path "target/buildpack/release/$ESCAPED_ID" "${PACKAGE}:${VERSION}"
-                pack buildpack package --format file  --path "target/buildpack/release/$ESCAPED_ID" "${ESCAPED_ID}_${VERSION}.cnb"
-
-                DIGEST="$(crane digest ${PACKAGE}:${VERSION})"
-                echo "::set-output name=bp_id::$BP_ID"
-                echo "::set-output name=version::$VERSION"
-                echo "::set-output name=tag_name::v${VERSION}"
-                echo "::set-output name=address::${PACKAGE}@${DIGEST}"
-                echo "::set-output name=package::${ESCAPED_ID}_${VERSION}.cnb"
-              env:
-                REPO: docker.io/heroku/procfile-cnb
-
-            # Open a PR to the buildpack registry index.
-            # For example: https://github.com/buildpacks/registry-index/issues/2776
-            - id: register
-              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.2.0
-              with:
-                token:   ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
-                id:      ${{ steps.package.outputs.bp_id }}
-                version: ${{ steps.package.outputs.version }}
-                address: ${{ steps.package.outputs.address }}
-
-            # Create a release and tag on the github repo
-            # For example: https://github.com/heroku/procfile-cnb/releases/tag/v1.0.1
-            # Attaches the previously generated cloud native buildpack file (`*.cnb`)
-            # to the release
-            - id: release
-              name: Upload build package to release
-              uses: svenstaro/upload-release-action@2.6.1
-              with:
-                repo_token: ${{ secrets.GITHUB_TOKEN }}
-                file: ${{ steps.package.outputs.package }}
-                tag: ${{ steps.package.outputs.tag_name }}
-                overwrite: true
+  update-builder:
+    name: Update Builder
+    needs: [ detect, publish-docker, publish-cnb, publish-github ]
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-update-builder.yml@main
+    with:
+      app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+      buildpack_version: ${{ needs.detect.outputs.version }}
+    secrets:
+      app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,79 +3,14 @@ name: Release Buildpacks
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  detect:
-    name: Detecting Buildpacks
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-detect.yml@main
-
-  package:
-    name: ${{ matrix.buildpack_id }}
-    needs: [ detect ]
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-package.yml@main
-    with:
-      buildpack_id: ${{ matrix.buildpack_id }}
-      buildpack_dir: ${{ matrix.buildpack_dir }}
-      buildpack_version: ${{ matrix.buildpack_version }}
-      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
-
-  publish-docker:
-    name: ${{ matrix.buildpack_id }}
-    needs: [ detect, package ]
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-docker.yml@main
-    with:
-      buildpack_id: ${{ matrix.buildpack_id }}
-      buildpack_version: ${{ matrix.buildpack_version }}
-      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
-      docker_repository: ${{ matrix.docker_repository }}
-    secrets:
-      docker_hub_user: ${{ secrets.DOCKER_HUB_USER }}
-      docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-  publish-github:
-    name: ${{ matrix.buildpack_id }}
-    needs: [ detect, package ]
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-github.yml@main
-    with:
-      buildpack_version: ${{ matrix.buildpack_version }}
-      buildpack_artifact_prefix: ${{ matrix.buildpack_artifact_prefix }}
-
-  publish-cnb:
-    name: ${{ matrix.buildpack_id }}
-    needs: [ detect, publish-docker ]
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.detect.outputs.buildpacks) }}
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-publish-cnb-registry.yml@main
-    with:
-      buildpack_id: ${{ matrix.buildpack_id }}
-      buildpack_version: ${{ matrix.buildpack_version }}
-      docker_repository: ${{ matrix.docker_repository }}
-    secrets:
-      cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
-
-  update-builder:
-    name: Update Builder
-    needs: [ detect, publish-docker, publish-cnb, publish-github ]
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release-update-builder.yml@main
+  release:
+    name: Release
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@main
     with:
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-      buildpack_version: ${{ needs.detect.outputs.version }}
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+      cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}
+      docker_hub_user: ${{ secrets.DOCKER_HUB_USER }}
+      docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,25 +7,6 @@ This is a [Cloud Native Buildpack](https://buildpacks.io/) that replicates the b
 
 It is written in Rust using the Cloud Native Buildpack framework [libcnb.rs](https://github.com/heroku/libcnb.rs).
 
-## Deployment
-
-### 0) Prerelease
-
-- Ensure that the version in `buildpack.toml` is correct. The following deployment steps will create a release with the that version number.
-- Ensure there's an entry for the same version in `CHANGELOG.md`.
-
-### 1) Generate a release
-
-- Visit the actions page https://github.com/heroku/procfile-cnb/actions,
-- Click on "release" and then "Run workflow".
-
-When the action is successful a release will be added to https://github.com/heroku/procfile-cnb/releases and docker hub https://hub.docker.com/r/heroku/procfile-cnb/tags.
-
-### 2) Update builders
-
-Heroku builders (github.com/heroku/builders) must be updated to the latest
-version of the buildpack. A detailed procedure is available [here](github.com/heroku/languages-team/blob/main/languages/cnb/deploy.md#update-builder-images).
-
 ## Development
 
 ### Prerequisites
@@ -67,3 +48,7 @@ Processes:
   web (default)        bash         echo 'this is the web process!'                       /workspace
   worker               bash         echo 'this is the worker process!'                    /workspace
 ```
+
+## Releasing
+
+[Deploy Cloud Native Buildpacks](https://github.com/heroku/languages-team/blob/main/languages/cnb/deploy.md)

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -14,7 +14,5 @@ id = "*"
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
-[metadata]
 [metadata.release]
-[metadata.release.image]
-repository = "docker.io/heroku/procfile-cnb"
+image = { repository = "docker.io/heroku/procfile-cnb" }

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -13,3 +13,8 @@ id = "*"
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
+
+[metadata]
+[metadata.release]
+[metadata.release.docker]
+repository = "docker.io/heroku/procfile-cnb"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,5 +16,5 @@ type = "BSD-3-Clause"
 
 [metadata]
 [metadata.release]
-[metadata.release.docker]
+[metadata.release.image]
 repository = "docker.io/heroku/procfile-cnb"


### PR DESCRIPTION
This sets up the release automation scripts from [languages-github-actions](https://github.com/heroku/languages-github-actions) for the Procfile buildpack.

Also in this PR:
* adds the target Docker repository to `buildpack.toml` to align with the metadata used by other Heroku buildpacks

[W-13658758](https://gus.lightning.force.com/a07EE00001UkuZgYAJ)