### PR TITLE
Use stable release of release automation workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,9 +15,9 @@ on:
 
 jobs:
   prepare-release:
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-prepare-release.yml@main
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-prepare-release.yml@latest
     with:
-      bump: ${{ inputs.bump }}
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+      bump: ${{ inputs.bump }}
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,19 @@ name: Release Buildpack
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Execute the release workflow but skip any steps that publish (for testing purposes)
+        type: boolean
+        default: false
 
 jobs:
   release:
     name: Release
-    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@main
+    uses: heroku/languages-github-actions/.github/workflows/_buildpacks-release.yml@latest
     with:
       app_id: ${{ vars.LINGUIST_GH_APP_ID }}
+      dry_run: ${{ inputs.dry_run }}
     secrets:
       app_private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
       cnb_registry_token: ${{ secrets.CNB_REGISTRY_RELEASE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
The previous workflow reference of `@main` was the  unstable development version of our release automation. The `@latest` ref points to the most recent stable version of the workflows.