### PR TITLE
Update buildpack metadata in buildpack.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated buildpack display name, description and keywords. ([#189](https://github.com/heroku/procfile-cnb/pull/189))
+
 ## [2.0.1] - 2023-08-21
 
 ### Changed

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,16 +3,16 @@ api = "0.8"
 [buildpack]
 id = "heroku/procfile"
 version = "2.0.1"
-name = "Procfile"
+name = "Heroku Procfile"
 homepage = "https://github.com/heroku/procfile-cnb"
-description = "Official Heroku buildpack for using Procfile."
-keywords = ["procfile", "processes"]
-
-[[stacks]]
-id = "*"
+description = "Heroku's Procfile buildpack."
+keywords = ["procfile", "processes", "heroku"]
 
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
+
+[[stacks]]
+id = "*"
 
 [metadata.release]
 image = { repository = "docker.io/heroku/procfile-cnb" }


### PR DESCRIPTION
Adjusts the buildpack `name`, `description` and `keywords` in `buildpack.toml` to match the style discussed in:
https://github.com/heroku/cnb-builder-images/issues/408

These fields are used by the CNB registry and can also be seen in the output of `pack builder inspect`. They are not used by `pack build` or Kodon.

GUS-W-14121598.