### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,13 @@ name = "procfile-buildpack"
 version = "0.0.0"
 publish = false
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.74"
+
+[lints.rust]
+unused_crate_dependencies = "warn"
+
+[lints.clippy]
+pedantic = "warn"
 
 [dependencies]
 indoc = "2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,12 +4,18 @@ use indoc::formatdoc;
 use libherokubuildpack::log::log_error;
 
 #[derive(Debug)]
+// This allow can be removed once the visibility of this enum is fixed,
+// since the lint only applies to public APIs.
+#[allow(clippy::module_name_repetitions)]
 pub enum ProcfileBuildpackError {
     CannotReadProcfileContents(std::io::Error),
     ProcfileParsingError(ProcfileParsingError),
     ProcfileConversionError(ProcfileConversionError),
 }
 
+// This allow can be removed once the visibility of this enum is fixed,
+// since the lint only applies to public APIs.
+#[allow(clippy::module_name_repetitions)]
 pub fn error_handler(buildpack_error: ProcfileBuildpackError) {
     match buildpack_error {
         ProcfileBuildpackError::CannotReadProcfileContents(io_error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,3 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
-#![warn(unused_crate_dependencies)]
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// Re-disable pedantic lints that are too noisy/unwanted.
-#![allow(clippy::module_name_repetitions)]
-
 mod error;
 mod launch;
 mod procfile;

--- a/src/procfile.rs
+++ b/src/procfile.rs
@@ -64,6 +64,9 @@ impl FromStr for Procfile {
 // There are currently no ways in which parsing can fail, however we will add some in the future:
 // https://github.com/heroku/procfile-cnb/issues/73
 #[derive(Debug, Eq, PartialEq)]
+// This allow can be removed once the visibility of this enum is fixed,
+// since the lint only applies to public APIs.
+#[allow(clippy::module_name_repetitions)]
 pub enum ProcfileParsingError {}
 
 #[cfg(test)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,10 +1,8 @@
-//! Integration tests using libcnb-test.
-//!
-//! All integration tests are skipped by default (using the `ignore` attribute),
-//! since performing builds is slow. To run the tests use: `cargo test -- --ignored`
+//! All integration tests are skipped by default (using the `ignore` attribute)
+//! since performing builds is slow. To run them use: `cargo test -- --ignored`.
 
-// Enable Clippy lints that are disabled by default.
-#![warn(clippy::pedantic)]
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
 
 use indoc::indoc;
 use libcnb_test::{assert_contains, BuildConfig, ContainerConfig, PackResult, TestRunner};


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in `Cargo.toml` across whole crates/workspaces:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section

This reduces the boilerplate, and the chance that we forget to enable lints in some targets.

Since this feature requires Rust 1.74, the MSRV has also been bumped.

GUS-W-14523760.