### PR TITLE
Enable additional rustc and Clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,14 @@ edition = "2021"
 rust-version = "1.74"
 
 [lints.rust]
+unreachable_pub = "warn"
+unsafe_code = "warn"
 unused_crate_dependencies = "warn"
 
 [lints.clippy]
+panic_in_result_fn = "warn"
 pedantic = "warn"
+unwrap_used = "warn"
 
 [dependencies]
 indoc = "2"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,19 +4,13 @@ use indoc::formatdoc;
 use libherokubuildpack::log::log_error;
 
 #[derive(Debug)]
-// This allow can be removed once the visibility of this enum is fixed,
-// since the lint only applies to public APIs.
-#[allow(clippy::module_name_repetitions)]
-pub enum ProcfileBuildpackError {
+pub(crate) enum ProcfileBuildpackError {
     CannotReadProcfileContents(std::io::Error),
     ProcfileParsingError(ProcfileParsingError),
     ProcfileConversionError(ProcfileConversionError),
 }
 
-// This allow can be removed once the visibility of this enum is fixed,
-// since the lint only applies to public APIs.
-#[allow(clippy::module_name_repetitions)]
-pub fn error_handler(buildpack_error: ProcfileBuildpackError) {
+pub(crate) fn error_handler(buildpack_error: ProcfileBuildpackError) {
     match buildpack_error {
         ProcfileBuildpackError::CannotReadProcfileContents(io_error) => {
             log_error(

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -35,7 +35,7 @@ impl TryFrom<Procfile> for Launch {
 }
 
 #[derive(Debug)]
-pub enum ProcfileConversionError {
+pub(crate) enum ProcfileConversionError {
     InvalidProcessType(libcnb::data::launch::ProcessTypeError),
 }
 

--- a/src/procfile.rs
+++ b/src/procfile.rs
@@ -3,22 +3,23 @@ use regex::Regex;
 use std::str::FromStr;
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct Procfile {
-    pub processes: LinkedHashMap<String, String>,
+pub(crate) struct Procfile {
+    pub(crate) processes: LinkedHashMap<String, String>,
 }
 
 impl Procfile {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Procfile {
             processes: LinkedHashMap::new(),
         }
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.processes.is_empty()
     }
 
-    pub fn insert(&mut self, k: impl Into<String>, v: impl Into<String>) {
+    #[cfg(test)]
+    pub(crate) fn insert(&mut self, k: impl Into<String>, v: impl Into<String>) {
         self.processes.insert(k.into(), v.into());
     }
 }
@@ -64,10 +65,7 @@ impl FromStr for Procfile {
 // There are currently no ways in which parsing can fail, however we will add some in the future:
 // https://github.com/heroku/procfile-cnb/issues/73
 #[derive(Debug, Eq, PartialEq)]
-// This allow can be removed once the visibility of this enum is fixed,
-// since the lint only applies to public APIs.
-#[allow(clippy::module_name_repetitions)]
-pub enum ProcfileParsingError {}
+pub(crate) enum ProcfileParsingError {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Enables some off-by-default lints that we already use in the `libcnb.rs` repository.

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub
https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-code
https://rust-lang.github.io/rust-clippy/master/index.html#/panic_in_result_fn
https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_used

GUS-W-14523760.