### PR TITLE
Simplify Cargo metadata for `publish = false` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "procfile-buildpack"
-# The crate is not published, so the only version that is used is the one in buildpack.toml.
-version = "0.0.0"
-publish = false
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.75"
 
 [lints.rust]
 unreachable_pub = "warn"


### PR DESCRIPTION
As of Cargo 1.75 the `version` property in `Cargo.toml` is now optional, and if omitted is the same as having specified `version = "0.0.0"` and `publish = false`:
https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28
https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field

Therefore for crates that we do not publish, we can now remove both the `version` and `publish` properties, avoiding the need for the fake `0.0.0` version that differs from the actual buildpack version in `buildpack.toml`.

GUS-W-14821120.