### PR TITLE
Remove unnecessary package.toml

### DIFF
--- a/package.toml
+++ b/package.toml
@@ -1,2 +1,0 @@
-[buildpack]
-uri = "."


### PR DESCRIPTION
The current `package.toml` contents is equivalent to the default config, so the file is redundant. The CNB release automation handles this file not existing just fine (eg see the Python CNB repo).