### PR TITLE
Prepare 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2024-02-22
+
 ### Changed
 
 - Update to Buildpack API 0.10. ([#205](https://github.com/heroku/procfile-cnb/pull/205)
@@ -62,7 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of Rust procfile buildpack, the old Go buildpack is now archived.
 - Re-write logic of Procfile parsing to match Heroku's behavior, which has different behavior from the Go version (that assumed that a Procfile was YAML syntax).
 
-[unreleased]: https://github.com/heroku/procfile-cnb/compare/v2.0.2...HEAD
+[unreleased]: https://github.com/heroku/procfile-cnb/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/heroku/procfile-cnb/compare/v2.0.2...v3.0.0
 [2.0.2]: https://github.com/heroku/procfile-cnb/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/heroku/procfile-cnb/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/heroku/procfile-cnb/compare/v1.0.2...v2.0.0

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "heroku/procfile"
-version = "2.0.2"
+version = "3.0.0"
 name = "Heroku Procfile"
 homepage = "https://github.com/heroku/procfile-cnb"
 description = "Heroku's Procfile buildpack."


### PR DESCRIPTION
This release has some rather impactful changes, so flagging it as a major version release.

This PR was created manually, due to heroku/languages-github-actions not being compatible with Buildpack API 0.10 just yet (see [this failed action](https://github.com/heroku/procfile-cnb/actions/runs/8006108961/job/21867056142) and [this comment on libcnb.rs](https://github.com/heroku/libcnb.rs/issues/788#issuecomment-1960061720)).


### Changed

- Update to Buildpack API 0.10. ([#205](https://github.com/heroku/procfile-cnb/pull/205)
    - All launch processes are now wrapped in `bash -c` instead of using CNB's `direct = false` directive, which is no longer available.
    - `.profile` and `.profile.d` scripts will no longer be automatically sourced.
    - CNB Lifecycle 0.17 or newer is now required.