### PR TITLE
Reintroduce `[[stacks]]` table to workaround release issues.

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,6 +11,13 @@ keywords = ["procfile", "processes", "heroku"]
 [[buildpack.licenses]]
 type = "BSD-3-Clause"
 
+# [[stacks]] is deprecated in Buildpack API 0.10, but is (unintentionally?)
+# required by `pack buildpack package`. The [[stacks]] table should be
+# removed when the issue (https://github.com/buildpacks/pack/issues/2047) is
+# resolved.
+[[stacks]]
+id = "*"
+
 [[targets]]
 os = "linux"
 arch = "amd64"


### PR DESCRIPTION
The 3.0.0 release is currently blocked: https://github.com/heroku/procfile-cnb/actions/runs/8025023370/job/21924849039. It's failing with `ERROR: saving image: no compatible stacks among provided buildpacks`.

The issue is that `pack buildpack package` requires `[[stacks]]` to be present in `buildpack.toml`, which is unexpected (and maybe unintentional), since `[[stacks]]` were [deprecated in Buildpack API 0.10](https://github.com/buildpacks/spec/blob/buildpack/v0.10/buildpack.md#buildpacktoml-toml-stacks-array).

We could wait for an upstream fix (like https://github.com/buildpacks/pack/pull/2081 🤞🏻 ), or we could workaround the issue by adding the `[[stacks]]` table back in. 

Functionally, having no `[[stacks]]` table and having `[[stacks]] id = "*"` seem to be the same. And while the `[[stacks]]` table is deprecated, there isn't any messaging saying so in the pack output. So, the only downside that I see to adding `[[stacks]]` back in is that we'll probably want to remove it again later. 