### PR TITLE
Update v3.0.0 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0] - 2024-02-23
+## [3.0.0] - 2024-02-28
 
 ### Added
 


### PR DESCRIPTION
Since the original release was delayed due to the packaging step failing (see #210).

(I've used 28th not 27th for the date, since we/the automation use UTC dates in the changelog.)