### PR TITLE
Prepare repository rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Enabled tracing/telemetry via `libcnb`'s `trace` feature. ([#208](https://github.com/heroku/procfile-cnb/pull/208))
+- Enabled tracing/telemetry via `libcnb`'s `trace` feature. ([#208](https://github.com/heroku/buildpacks-procfile/pull/208))
 
 ### Changed
 
-- Updated to Buildpack API 0.10. ([#205](https://github.com/heroku/procfile-cnb/pull/205))
+- Updated to Buildpack API 0.10. ([#205](https://github.com/heroku/buildpacks-procfile/pull/205))
     - All launch processes are now wrapped in `bash -c` instead of using CNB's `direct = false` directive, which is no longer available.
     - `.profile` and `.profile.d` scripts will no longer be automatically sourced.
     - CNB Lifecycle 0.17 or newer is now required.
@@ -24,42 +24,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated buildpack display name, description and keywords. ([#189](https://github.com/heroku/procfile-cnb/pull/189))
+- Updated buildpack display name, description and keywords. ([#189](https://github.com/heroku/buildpacks-procfile/pull/189))
 
 ## [2.0.1] - 2023-08-21
 
 ### Changed
 
-- Switched to new buildpack release automation. As a side-effect, the filename of the packaged buildpack attached to the GitHub release has changed from `heroku_procfile_X.Y.Z.cnb` to `heroku_procfile.cnb`. ([#156](https://github.com/heroku/procfile-cnb/pull/156) and [#170](https://github.com/heroku/procfile-cnb/pull/170))
+- Switched to new buildpack release automation. As a side-effect, the filename of the packaged buildpack attached to the GitHub release has changed from `heroku_procfile_X.Y.Z.cnb` to `heroku_procfile.cnb`. ([#156](https://github.com/heroku/buildpacks-procfile/pull/156) and [#170](https://github.com/heroku/buildpacks-procfile/pull/170))
 - Updated buildpack dependencies.
 
 ## [2.0.0] - 2022-09-27
 
 ### Changed
 
-- Buildpack now implements buildpack API version 0.8 and so requires `lifecycle` version 0.14.x or newer. ([#98](https://github.com/heroku/procfile-cnb/pull/98))
-- Upgraded `libcnb` and `libherokubuildpack` to 0.11.0. ([#98](https://github.com/heroku/procfile-cnb/pull/98) and [#102](https://github.com/heroku/procfile-cnb/pull/102))
+- Buildpack now implements buildpack API version 0.8 and so requires `lifecycle` version 0.14.x or newer. ([#98](https://github.com/heroku/buildpacks-procfile/pull/98))
+- Upgraded `libcnb` and `libherokubuildpack` to 0.11.0. ([#98](https://github.com/heroku/buildpacks-procfile/pull/98) and [#102](https://github.com/heroku/buildpacks-procfile/pull/102))
 
 ### Removed
 
-- Removed explicitly named stacks from `[[stacks]]`, which were a workaround for Pack CLI <0.24.1 not supporting the wildcard stack. ([#103](https://github.com/heroku/procfile-cnb/pull/103))
+- Removed explicitly named stacks from `[[stacks]]`, which were a workaround for Pack CLI <0.24.1 not supporting the wildcard stack. ([#103](https://github.com/heroku/buildpacks-procfile/pull/103))
 
 ## [1.0.2] - 2022-07-14
 
 ### Changed
 
 - The buildpack binary is now stripped for reduced builder image size (thanks to [`libcnb-cargo` v0.5.0](https://github.com/heroku/libcnb.rs/releases/tag/libcnb-cargo%2Fv0.5.0)).
-- Updated `libcnb` and `libherokubuildpack` from 0.5.0 to 0.9.0. ([#49](https://github.com/heroku/procfile-cnb/pull/49), [#60](https://github.com/heroku/procfile-cnb/pull/60), [#82](https://github.com/heroku/procfile-cnb/pull/82) and [#88](https://github.com/heroku/procfile-cnb/pull/88))
+- Updated `libcnb` and `libherokubuildpack` from 0.5.0 to 0.9.0. ([#49](https://github.com/heroku/buildpacks-procfile/pull/49), [#60](https://github.com/heroku/buildpacks-procfile/pull/60), [#82](https://github.com/heroku/buildpacks-procfile/pull/82) and [#88](https://github.com/heroku/buildpacks-procfile/pull/88))
 
 ### Fixed
 
-- Removed incorrect error message shown in the case of internal buildpack regex errors. ([#77](https://github.com/heroku/procfile-cnb/pull/77))
+- Removed incorrect error message shown in the case of internal buildpack regex errors. ([#77](https://github.com/heroku/buildpacks-procfile/pull/77))
 
 ## [1.0.1] - 2022-04-05
 
 ### Fixed
 
-- Fixed compatibility with older versions of Pack CLI that do not support the wildcard stack in `buildpack.toml`. ([#55](https://github.com/heroku/procfile-cnb/pull/55))
+- Fixed compatibility with older versions of Pack CLI that do not support the wildcard stack in `buildpack.toml`. ([#55](https://github.com/heroku/buildpacks-procfile/pull/55))
 
 ## [1.0.0] - 2022-04-05
 
@@ -68,11 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of Rust procfile buildpack, the old Go buildpack is now archived.
 - Re-write logic of Procfile parsing to match Heroku's behavior, which has different behavior from the Go version (that assumed that a Procfile was YAML syntax).
 
-[unreleased]: https://github.com/heroku/procfile-cnb/compare/v3.0.0...HEAD
-[3.0.0]: https://github.com/heroku/procfile-cnb/compare/v2.0.2...v3.0.0
-[2.0.2]: https://github.com/heroku/procfile-cnb/compare/v2.0.1...v2.0.2
-[2.0.1]: https://github.com/heroku/procfile-cnb/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/heroku/procfile-cnb/compare/v1.0.2...v2.0.0
-[1.0.2]: https://github.com/heroku/procfile-cnb/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/heroku/procfile-cnb/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/heroku/procfile-cnb/releases/tag/v1.0.0
+[unreleased]: https://github.com/heroku/buildpacks-procfile/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/heroku/buildpacks-procfile/compare/v2.0.2...v3.0.0
+[2.0.2]: https://github.com/heroku/buildpacks-procfile/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/heroku/buildpacks-procfile/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/heroku/buildpacks-procfile/compare/v1.0.2...v2.0.0
+[1.0.2]: https://github.com/heroku/buildpacks-procfile/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/heroku/buildpacks-procfile/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/heroku/buildpacks-procfile/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Changed repository name from `heroku/procfile-cnb` to `heroku/buildpacks-procfile`. ([#216](https://github.com/heroku/buildpacks-procfile/pull/216))
+
 ## [3.0.0] - 2024-02-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heroku Cloud Native Procfile Buildpack
 
-[![CI](https://github.com/heroku/procfile-cnb/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/procfile-cnb/actions/workflows/ci.yml)
+[![CI](https://github.com/heroku/buildpacks-procfile/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/buildpacks-procfile/actions/workflows/ci.yml)
 
 This is a [Cloud Native Buildpack](https://buildpacks.io/) that replicates the behavior of
 [`Procfile`](https://devcenter.heroku.com/articles/procfile) from non-CNB Heroku Builds.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -4,7 +4,7 @@ api = "0.10"
 id = "heroku/procfile"
 version = "3.0.0"
 name = "Heroku Procfile"
-homepage = "https://github.com/heroku/procfile-cnb"
+homepage = "https://github.com/heroku/buildpacks-procfile"
 description = "Heroku's Procfile buildpack."
 keywords = ["procfile", "processes", "heroku"]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub(crate) fn error_handler(buildpack_error: ProcfileBuildpackError) {
             );
         }
         // There are currently no ways in which parsing can fail, however we will add some in the future:
-        // https://github.com/heroku/procfile-cnb/issues/73
+        // https://github.com/heroku/buildpacks-procfile/issues/73
         ProcfileBuildpackError::ProcfileParsingError(parsing_error) => match parsing_error {},
         ProcfileBuildpackError::ProcfileConversionError(conversion_error) => match conversion_error
         {

--- a/src/procfile.rs
+++ b/src/procfile.rs
@@ -63,7 +63,7 @@ impl FromStr for Procfile {
 }
 
 // There are currently no ways in which parsing can fail, however we will add some in the future:
-// https://github.com/heroku/procfile-cnb/issues/73
+// https://github.com/heroku/buildpacks-procfile/issues/73
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum ProcfileParsingError {}
 


### PR DESCRIPTION
This replaces all references of `github.com/heroku/procfile-cnb` with `github.com/heroku/buildpacks-procfile`. We're doing this to keep Heroku Cloud Native Buildpack repository names consistent and discoverable. The new naming will match others like:

- https://github.com/heroku/buildpacks-go
- https://github.com/heroku/buildpacks-jvm
- https://github.com/heroku/buildpacks-nodejs
- https://github.com/heroku/buildpacks-php
- https://github.com/heroku/buildpacks-python
- https://github.com/heroku/buildpacks-ruby