### PR TITLE
Allow passing custom arguments to the process (#310)

### DIFF
--- a/src/launch.rs
+++ b/src/launch.rs
@@ -16,8 +16,13 @@ impl TryFrom<Procfile> for Launch {
             launch.processes.push(Process {
                 r#type: ProcessType::from_str(&key)
                     .map_err(ProcfileConversionError::InvalidProcessType)?,
-                command: vec![String::from("bash"), String::from("-c")],
-                args: vec![value],
+                command: vec![
+                    String::from("bash"),
+                    String::from("-c"),
+                    format!("{value} \"$@\""),
+                    String::from("--"),
+                ],
+                args: vec![],
                 default: key == "web",
                 working_directory: WorkingDirectory::App,
             });
@@ -55,8 +60,13 @@ mod test {
             launch.processes,
             vec![Process {
                 r#type: process_type!("web"),
-                command: vec![String::from("bash"), String::from("-c")],
-                args: vec![String::from("web_command")],
+                command: vec![
+                    String::from("bash"),
+                    String::from("-c"),
+                    String::from("web_command \"$@\""),
+                    String::from("--"),
+                ],
+                args: vec![],
                 default: true,
                 working_directory: WorkingDirectory::App,
             }]
@@ -74,8 +84,13 @@ mod test {
             launch.processes,
             vec![Process {
                 r#type: process_type!("xxx"),
-                command: vec![String::from("bash"), String::from("-c")],
-                args: vec![String::from("xxx_command")],
+                command: vec![
+                    String::from("bash"),
+                    String::from("-c"),
+                    String::from("xxx_command \"$@\""),
+                    String::from("--"),
+                ],
+                args: vec![],
                 default: true,
                 working_directory: WorkingDirectory::App,
             }]
@@ -95,15 +110,25 @@ mod test {
             vec![
                 Process {
                     r#type: process_type!("web"),
-                    command: vec![String::from("bash"), String::from("-c")],
-                    args: vec![String::from("web_command")],
+                    command: vec![
+                        String::from("bash"),
+                        String::from("-c"),
+                        String::from("web_command \"$@\""),
+                        String::from("--"),
+                    ],
+                    args: vec![],
                     default: true,
                     working_directory: WorkingDirectory::App,
                 },
                 Process {
                     r#type: process_type!("foo"),
-                    command: vec![String::from("bash"), String::from("-c")],
-                    args: vec![String::from("foo_command")],
+                    command: vec![
+                        String::from("bash"),
+                        String::from("-c"),
+                        String::from("foo_command \"$@\""),
+                        String::from("--"),
+                    ],
+                    args: vec![],
                     default: false,
                     working_directory: WorkingDirectory::App,
                 }
@@ -124,15 +149,25 @@ mod test {
             vec![
                 Process {
                     r#type: process_type!("foo"),
-                    command: vec![String::from("bash"), String::from("-c")],
-                    args: vec![String::from("foo_command")],
+                    command: vec![
+                        String::from("bash"),
+                        String::from("-c"),
+                        String::from("foo_command \"$@\""),
+                        String::from("--"),
+                    ],
+                    args: vec![],
                     default: false,
                     working_directory: WorkingDirectory::App,
                 },
                 Process {
                     r#type: process_type!("bar"),
-                    command: vec![String::from("bash"), String::from("-c")],
-                    args: vec![String::from("bar_command")],
+                    command: vec![
+                        String::from("bash"),
+                        String::from("-c"),
+                        String::from("bar_command \"$@\""),
+                        String::from("--"),
+                    ],
+                    args: vec![],
                     default: false,
                     working_directory: WorkingDirectory::App,
                 }
@@ -162,22 +197,37 @@ mod test {
             vec![
                 Process {
                     r#type: process_type!("aaa"),
-                    command: vec![String::from("bash"), String::from("-c")],
-                    args: vec![String::from("aaa_command")],
+                    command: vec![
+                        String::from("bash"),
+                        String::from("-c"),
+                        String::from("aaa_command \"$@\""),
+                        String::from("--"),
+                    ],
+                    args: vec![],
                     default: false,
                     working_directory: WorkingDirectory::App,
                 },
                 Process {
                     r#type: process_type!("ccc"),
-                    command: vec![String::from("bash"), String::from("-c")],
-                    args: vec![String::from("ccc_command")],
+                    command: vec![
+                        String::from("bash"),
+                        String::from("-c"),
+                        String::from("ccc_command \"$@\""),
+                        String::from("--"),
+                    ],
+                    args: vec![],
                     default: false,
                     working_directory: WorkingDirectory::App,
                 },
                 Process {
                     r#type: process_type!("bbb"),
-                    command: vec![String::from("bash"), String::from("-c")],
-                    args: vec![String::from("bbb_command")],
+                    command: vec![
+                        String::from("bash"),
+                        String::from("-c"),
+                        String::from("bbb_command \"$@\""),
+                        String::from("--"),
+                    ],
+                    args: vec![],
                     default: false,
                     working_directory: WorkingDirectory::App,
                 },


### PR DESCRIPTION
By having the command be in the `args`, when passing custom args to the process the command was being lost, and by having `bash -c`, all the args were being lost too.

This adds the  `"$@"` variable to the bash script being executed, so the args are passed to the configured procfile entry, and moves it to the `command` section so the procfile entry is not being overridden.