### PR TITLE
Update default builder in README to heroku/builder:26

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To build an application codebase with a `Procfile` into a production image:
 
 ```bash
 $ cd ~/workdir/sample-procfile-app
-$ pack build sample-app --builder heroku/builder:24
+$ pack build sample-app --builder heroku/builder:26
 ```
 
 Then run the image:


### PR DESCRIPTION
Updates the README usage example to use heroku/builder:26.

GUS-W-22580946.